### PR TITLE
Update site description to remove draw reference

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -18,19 +18,19 @@ export const viewport: Viewport = {
 
 export const metadata: Metadata = {
   title: "ourfeelings.art — a river of feelings",
-  description: "Draw how you feel. Watch the world's emotions flow by.",
+  description: "Watch the world's emotions flow by.",
   keywords: ["feelings", "emotions", "art", "interactive", "ambient", "meditation"],
   authors: [{ name: "ourfeelings.art" }],
   openGraph: {
     title: "ourfeelings.art — a river of feelings",
-    description: "Draw how you feel. Watch the world's emotions flow by.",
+    description: "Watch the world's emotions flow by.",
     type: "website",
     url: "https://ourfeelings.art",
   },
   twitter: {
     card: "summary_large_image",
     title: "ourfeelings.art — a river of feelings",
-    description: "Draw how you feel. Watch the world's emotions flow by.",
+    description: "Watch the world's emotions flow by.",
   },
 };
 


### PR DESCRIPTION
## Summary
- Simplify the meta description from "Draw how you feel. Watch the world's emotions flow by." to just "Watch the world's emotions flow by."
- Updated across all metadata fields: description, OpenGraph, and Twitter

## Test plan
- [ ] Verify meta tags render correctly in browser dev tools
- [ ] Check OpenGraph preview with a sharing debugger tool

🤖 Generated with [Claude Code](https://claude.com/claude-code)